### PR TITLE
Feat[overview]: overview 페이지 엔티티, 목데이터 추가

### DIFF
--- a/src/entities/user/user.entity.ts
+++ b/src/entities/user/user.entity.ts
@@ -1,3 +1,9 @@
+export interface UserInfo {
+  name: string;
+  imageUrl: string;
+  joinDate: Date; // ISO Date 객체
+}
+
 // 주문 타입: 구매 or 판매
 export type OrderType = "buy" | "sell";
 

--- a/src/entities/user/user.entity.ts
+++ b/src/entities/user/user.entity.ts
@@ -1,7 +1,19 @@
+// 기본 유저 정보
 export interface UserInfo {
   name: string;
   imageUrl: string;
   joinDate: Date; // ISO Date 객체
+}
+
+// 유저 프로필 카드 옆 잔액, 수익률 데이터
+export interface UserPortfolioSummary {
+  totalAsset: number; //  250234750
+  returnRate: number; // 120.8 (%)
+}
+
+export interface UserBalanceSummary {
+  availableAmount: number; // 주문 가능 금액
+  investedAmount: number; // 현재 투자 중인 금액
 }
 
 // 주문 타입: 구매 or 판매

--- a/src/entities/user/user.mock.ts
+++ b/src/entities/user/user.mock.ts
@@ -1,4 +1,26 @@
-import type { OrderHistoryItem } from "./user.entity";
+import type {
+  OrderHistoryItem,
+  UserBalanceSummary,
+  UserInfo,
+  UserPortfolioSummary,
+} from "./user.entity";
+
+export const mockUserInfo: UserInfo = {
+  name: "강민재",
+  imageUrl:
+    "https://firebasestorage.googleapis.com/v0/b/blog-2b12b.appspot.com/o/profile_sponge.png?alt=media&token=63e9e64d-3c8f-4ee7-9b75-18095ca6af16",
+  joinDate: new Date("2025-04-25T11:30:00"),
+};
+
+export const mockUserPortfolioSummary: UserPortfolioSummary = {
+  totalAsset: 250234750,
+  returnRate: -120.8,
+};
+
+export const mockUserBalanceSummary: UserBalanceSummary = {
+  availableAmount: 20000000,
+  investedAmount: 350000,
+};
 
 export const mockPendingOrderData: OrderHistoryItem[] = [
   {

--- a/src/entities/user/user.store.ts
+++ b/src/entities/user/user.store.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+import type { UserInfo } from "./user.entity";
+
+interface UserStore {
+  userInfo: UserInfo | null;
+  setUserInfo: (info: UserInfo) => void;
+  clearUserInfo: () => void;
+  isLoggedIn: boolean;
+  setLoggedIn: (state: boolean) => void;
+}
+
+export const useUserStore = create<UserStore>((set) => ({
+  userInfo: null,
+  setUserInfo: (info: UserInfo) => set({ userInfo: info }),
+  clearUserInfo: () => set({ userInfo: null, isLoggedIn: false }),
+  isLoggedIn: false,
+  setLoggedIn: (state) => set({ isLoggedIn: state }),
+}));

--- a/src/entities/user/user.store.ts
+++ b/src/entities/user/user.store.ts
@@ -14,5 +14,5 @@ export const useUserStore = create<UserStore>((set) => ({
   setUserInfo: (info: UserInfo) => set({ userInfo: info }),
   clearUserInfo: () => set({ userInfo: null, isLoggedIn: false }),
   isLoggedIn: false,
-  setLoggedIn: (state) => set({ isLoggedIn: state }),
+  setLoggedIn: (state: boolean) => set({ isLoggedIn: state }),
 }));

--- a/src/features/investmentStatus/ui/InvestmentStatus.tsx
+++ b/src/features/investmentStatus/ui/InvestmentStatus.tsx
@@ -6,10 +6,10 @@ import {
 } from "@tanstack/react-table";
 import { useMemo } from "react";
 
-import Typography from "@/shared/components/atoms/Typography";
-import URL from "@/shared/constants/URL";
 import type { StockPortfolio } from "@/entities/stock/stock.entity";
 import { mockPortfolioData } from "@/entities/stock/stock.mock";
+import Typography from "@/shared/components/atoms/Typography";
+import URL from "@/shared/constants/URL";
 import cn from "@/shared/utils/cn";
 import { formatNumber } from "@/shared/utils/format";
 import { useNavigate } from "react-router-dom";
@@ -79,7 +79,7 @@ function InvestmentStatusTable() {
         header: "등락률",
         cell: (info) => {
           const fluctuationRate = info.getValue() as number;
-          return <Typography.P1>{`${fluctuationRate}`}</Typography.P1>;
+          return <Typography.P1>{`${fluctuationRate}%`}</Typography.P1>;
         },
       },
     ],

--- a/src/features/myAmount/ui/MyAmount.tsx
+++ b/src/features/myAmount/ui/MyAmount.tsx
@@ -1,6 +1,8 @@
-import Typography from "@/shared/components/atoms/Typography";
-import Card from "@/shared/components/atoms/Card";
+import { mockUserBalanceSummary } from "@/entities/user/user.mock";
 import Button from "@/shared/components/atoms/Button";
+import Card from "@/shared/components/atoms/Card";
+import Typography from "@/shared/components/atoms/Typography";
+import { formatNumber } from "@/shared/utils/format";
 
 function MyAmount() {
   return (
@@ -15,7 +17,9 @@ function MyAmount() {
             <Card.Header>주문 가능 금액</Card.Header>
           </Typography.Head3>
           <Typography.SubTitle1>
-            <Card.Content>100,000,000원</Card.Content>
+            <Card.Content>
+              {formatNumber(mockUserBalanceSummary.availableAmount)}원
+            </Card.Content>
           </Typography.SubTitle1>
         </Card>
         <Card className="w-full gap-6">
@@ -23,7 +27,9 @@ function MyAmount() {
             <Card.Header>현재 투자 중인 금액</Card.Header>
           </Typography.Head3>
           <Typography.SubTitle1>
-            <Card.Content>50,000,000원</Card.Content>
+            <Card.Content>
+              {formatNumber(mockUserBalanceSummary.investedAmount)}원
+            </Card.Content>
           </Typography.SubTitle1>
         </Card>
       </div>

--- a/src/features/userInfo/ui/UserInfo.tsx
+++ b/src/features/userInfo/ui/UserInfo.tsx
@@ -1,23 +1,41 @@
-import Typography from "@/shared/components/atoms/Typography";
+import {
+  mockUserInfo,
+  mockUserPortfolioSummary,
+} from "@/entities/user/user.mock";
 import Card from "@/shared/components/atoms/Card";
+import Typography from "@/shared/components/atoms/Typography";
+import cn from "@/shared/utils/cn";
+import { formatFullDateToKorean, formatNumber } from "@/shared/utils/format";
 
 function UserInfo() {
   return (
     <Card>
       <div className="flex">
-        <div className="flex-shrink-0 w-[90px] h-[90px] rounded-full bg-otl-gray mr-6"></div>
+        <div className="flex-shrink-0 w-[90px] h-[90px] rounded-full bg-otl-gray mr-6 overflow-hidden">
+          <img src={mockUserInfo.imageUrl} />
+        </div>
         <div className="grow flex justify-between items-center">
           <Card.Content>
-            <Typography.Head2>강민재</Typography.Head2>
+            <Typography.Head2>{mockUserInfo.name}</Typography.Head2>
             <Typography.SubTitle2 className="text-otl-gray">
-              가입일 2020년 5월 30일
+              가입일: {formatFullDateToKorean(mockUserInfo.joinDate)}
             </Typography.SubTitle2>
           </Card.Content>
           <Card.Content>
-            <Typography.SubTitle1 className="text-otl-stock-up flex justify-end">
-              +120.8%
+            <Typography.SubTitle1
+              className={cn(
+                "flex justify-end",
+                mockUserPortfolioSummary.returnRate >= 0
+                  ? "text-otl-stock-up "
+                  : "text-otl-stock-down "
+              )}
+            >
+              {mockUserPortfolioSummary.returnRate >= 0 ? "+" : ""}
+              {mockUserPortfolioSummary.returnRate}%
             </Typography.SubTitle1>
-            <Typography.Head1>250,234,750원</Typography.Head1>
+            <Typography.Head1>
+              {formatNumber(mockUserPortfolioSummary.totalAsset)}원
+            </Typography.Head1>
           </Card.Content>
         </div>
       </div>

--- a/src/shared/components/molecules/Header.tsx
+++ b/src/shared/components/molecules/Header.tsx
@@ -1,3 +1,4 @@
+import { mockUserInfo } from "@/entities/user/user.mock";
 import URL from "@/shared/constants/URL";
 import { Link, useLocation } from "react-router-dom";
 import Typography from "../atoms/Typography";
@@ -42,7 +43,9 @@ function Header() {
         </div>
 
         <div className="w-[155px] flex justify-end">
-          <div className="border w-[40px] h-[40px] rounded-full bg-otl-gray"></div>
+          <div className="border w-[40px] h-[40px] rounded-full bg-otl-gray overflow-hidden">
+            <img src={mockUserInfo.imageUrl} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/shared/utils/format.ts
+++ b/src/shared/utils/format.ts
@@ -2,6 +2,14 @@
 export const formatNumber = (value: number) =>
   value.toLocaleString("ko-KR", { maximumFractionDigits: 0 });
 
+// 날짜 포맷 (예: "2025년 6월 12일")
+export function formatFullDateToKorean(date: Date): string {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}년 ${month}월 ${day}일`;
+}
+
 // 날짜 포맷 (예: "6월 12일")
 export function formatDateToKorean(date: Date): string {
   const month = date.getMonth() + 1;


### PR DESCRIPTION
## 유형

<!-- 해당되는 유형에 체크해주세요 -->

- [x] 🚀 Feat: 새 기능 추가
- [x] 🚑️ Fix: 버그 수정
- [x] ♻️ Refactor: 코드 리팩토링
- [ ] 🎨 Style: 코드 스타일 수정 (포맷팅, 세미콜론 등)
- [ ] 💄 Design: UI/스타일 수정 (CSS 등)
- [ ] 📝 Docs: 문서 추가/수정
- [ ] 💡 Comment: 주석 추가/수정
- [ ] 🎉 Init: 프로젝트 초기 설정
- [ ] 🚚 File: 파일/폴더 수정, 이동, 삭제
- [ ] 🐛 Bug: 버그 리포팅 (@FIXME 주석 포함)
- [ ] 🔨 Chore: 기타 (빌드, 패키지 매니저 수정 등)

## 작업 내용

- [Feat] overview 페이지에 사용할 유저 자산 요약 엔티티 및 목데이터 추가
- [Feat] 연·월·일 날짜 포맷팅 함수 유틸로 추가
- [Fix] 등락률에 단위(%)가 없던 문제 수정
- [Refactor] main 브랜치 변경사항(feat/user) 병합
- [Fix] Zustand store setLoggedIn 함수 타입 보완
- [Feat] User 엔티티, Zustand 기반 store 초기 구성

### 상세 설명 (선택)

- overview 상단 UI에 필요한 availableAmount, investedAmount, totalAssets, fluctuationRate 등을 관리하는 구조 설계
- 날짜 표시용 "2025년 4월 25일" 형식 포맷터 함수 유틸화
- 등락률 셀 표시 시 % 누락되던 문제 수정
