### PR TITLE
Feat[userinfo]: 사용자 정보 불러오기 구현

### DIFF
--- a/src/entities/user/user.entity.ts
+++ b/src/entities/user/user.entity.ts
@@ -1,8 +1,8 @@
 // [overview page] 유저 정보
 export interface UserInfo {
   name: string;
-  imageUrl: string;
-  joinDate: Date; // ISO Date 객체
+  profileImage: string;
+  createdAt: Date; // ISO Date 객체
 }
 
 // [overview page] 유저 프로필 카드 옆 잔액, 수익률 데이터

--- a/src/entities/user/user.mock.ts
+++ b/src/entities/user/user.mock.ts
@@ -13,9 +13,9 @@ import type {
 // [overview page] 유저 정보
 export const mockUserInfo: UserInfo = {
   name: "강민재",
-  imageUrl:
+  profileImage:
     "https://firebasestorage.googleapis.com/v0/b/blog-2b12b.appspot.com/o/profile_sponge.png?alt=media&token=63e9e64d-3c8f-4ee7-9b75-18095ca6af16",
-  joinDate: new Date("2025-04-25T11:30:00"),
+  createdAt: new Date("2025-04-25T11:30:00"),
 };
 
 // [overview page] 유저 프로필 카드 옆 잔액, 수익률 데이터

--- a/src/features/user/userInfo/service/userInfo.service.ts
+++ b/src/features/user/userInfo/service/userInfo.service.ts
@@ -1,0 +1,12 @@
+import type { UserInfo } from "@/entities/user/user.entity";
+import { API_END_POINT } from "@/shared/utils/fetcher";
+
+export async function getUserInfo(): Promise<UserInfo> {
+  const { url, method } = API_END_POINT.user.getUserInfo();
+  const result = await fetch(url, {
+    method: method,
+    credentials: "include",
+  });
+
+  return await result.json();
+}

--- a/src/features/user/userInfo/ui/UserInfo.tsx
+++ b/src/features/user/userInfo/ui/UserInfo.tsx
@@ -1,24 +1,27 @@
-import {
-  mockUserInfo,
-  mockUserPortfolioSummary,
-} from "@/entities/user/user.mock";
+import { mockUserPortfolioSummary } from "@/entities/user/user.mock";
 import Card from "@/shared/components/atoms/Card";
 import Typography from "@/shared/components/atoms/Typography";
 import cn from "@/shared/utils/cn";
 import { formatFullDateToKorean, formatNumber } from "@/shared/utils/format";
+import type { UserInfo } from "@/entities/user/user.entity";
+import { useUserStore } from "@/entities/user/user.store";
 
 function UserInfo() {
+  const { userInfo } = useUserStore();
+
+  if (!userInfo) return;
+
   return (
     <Card>
       <div className="flex">
         <div className="flex-shrink-0 w-[90px] h-[90px] rounded-full bg-otl-gray mr-6 overflow-hidden">
-          <img src={mockUserInfo.imageUrl} />
+          <img src={userInfo.profileImage} />
         </div>
         <div className="grow flex justify-between items-center">
           <Card.Content>
-            <Typography.Head2>{mockUserInfo.name}</Typography.Head2>
+            <Typography.Head2>{userInfo.name}</Typography.Head2>
             <Typography.SubTitle2 className="text-otl-gray">
-              가입일: {formatFullDateToKorean(mockUserInfo.joinDate)}
+              가입일: {formatFullDateToKorean(new Date(userInfo.createdAt))}
             </Typography.SubTitle2>
           </Card.Content>
           <Card.Content>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,5 @@
 import Header from "@/shared/components/molecules/Header";
-
 import { News } from "@/features/news/ui/News";
-
 import { MarketIndexSummary } from "@/features/market/ui/MarketIndexSummary";
 import StockTableBoard from "@/features/stock/liveStockTable/ui/StockTableBoard";
 import { login } from "@/features/user/login/service/login.service";
@@ -9,13 +7,27 @@ import Footer from "@/shared/components/molecules/Footer";
 import ScreenTooSmall from "@/shared/components/organisms/ScreenTooSmall";
 import useMediaQuery from "@/shared/hooks/useMediaQuery";
 import { useEffect } from "react";
+import { getUserInfo } from "@/features/user/userInfo/service/userInfo.service";
+import { useUserStore } from "@/entities/user/user.store";
 
 function HomePage() {
   const isTabletOrAbove = useMediaQuery();
+  const { isLoggedIn } = useUserStore();
 
   useEffect(() => {
     login();
   }, []);
+
+  async function getUserInfoFunction() {
+    const result = await getUserInfo();
+    useUserStore.getState().setUserInfo(result);
+  }
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      getUserInfoFunction();
+    }
+  }, [isLoggedIn]);
 
   if (!isTabletOrAbove) return <ScreenTooSmall />;
 

--- a/src/shared/components/molecules/Header.tsx
+++ b/src/shared/components/molecules/Header.tsx
@@ -1,4 +1,4 @@
-import { mockUserInfo } from "@/entities/user/user.mock";
+// import { mockUserInfo } from "@/entities/user/user.mock";
 import { useUserStore } from "@/entities/user/user.store";
 import LoginModal from "@/features/user/login/ui/LoginModal";
 import URL from "@/shared/constants/URL";
@@ -11,7 +11,7 @@ function Header() {
   const pathname = location.pathname;
   const isActive = (path: string) => pathname === path;
 
-  const { isLoggedIn } = useUserStore();
+  const { isLoggedIn, userInfo } = useUserStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -55,7 +55,7 @@ function Header() {
             {isLoggedIn ? (
               <div className="w-[155px] flex justify-end">
                 <div className="border w-[40px] h-[40px] rounded-full bg-otl-gray overflow-hidden">
-                  <img src={mockUserInfo.imageUrl} />
+                  <img src={userInfo?.profileImage} />
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
## 유형
- [x] 🚀 Feat: 새 기능 추가
- [ ] 🚑️ Fix: 버그 수정
- [x] ♻️ Refactor: 코드 리팩토링
- [ ] 🎨 Style: 코드 스타일 수정 (포맷팅, 세미콜론 등)
- [ ] 💄 Design: UI/스타일 수정 (CSS 등)
- [ ] 📝 Docs: 문서 추가/수정
- [ ] 💡 Comment: 주석 추가/수정
- [ ] 🎉 Init: 프로젝트 초기 설정
- [ ] 🚚 File: 파일/폴더 수정, 이동, 삭제
- [ ] 🐛 Bug: 버그 리포팅 (@FIXME 주석 포함)
- [ ] 🔨 Chore: 기타 (빌드, 패키지 매니저 수정 등)

## 작업 내용
- 로그인 완료 후 사용자 정보를 가져오는 api를 호출하고 해당 정보를 store에 저장
- 헤더, 투자 모아보기 페이지에서 store에서 프로필 사진과 이름을 가져오도록 함


## 스크린샷 (선택)
<img width="1173" height="263" alt="image" src="https://github.com/user-attachments/assets/0b30e68e-20db-42f0-957f-898a226b50d9" />

